### PR TITLE
Improve getter/setter Locale & support Deno Deploy

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -145,6 +145,7 @@ function middleware<C extends Context = Context>(
 ): MiddlewareFn<C & I18nFlavor> {
   return async function (ctx, next): Promise<void> {
     let translate: TranslateFunction;
+    let locale: LocaleId = ctx.from?.language_code || defaultLocale;
 
     function useLocale(locale: LocaleId): void {
       translate = fluent.withLocale(locale);
@@ -164,7 +165,7 @@ function middleware<C extends Context = Context>(
       useLocale(negotiatedLocale);
     }
 
-    async function setLocale(locale: LocaleId): Promise<void> {
+    async function setLocale(localeId: LocaleId): Promise<void> {
       if (!useSession) {
         throw new Error(
 "You are calling `ctx.i18n.setLocale()` without setting `useSession` to `true` \
@@ -177,7 +178,8 @@ should either enable sessions or use `ctx.i18n.useLocale()` instead.",
       }
 
       // deno-lint-ignore no-explicit-any
-      (await (ctx as any).session).__language_code = locale;
+      (await (ctx as any).session).__language_code = localeId;
+      locale = localeId;
       await negotiateLocale();
     }
 
@@ -195,6 +197,7 @@ should either enable sessions or use `ctx.i18n.useLocale()` instead.",
 
     ctx.i18n = {
       fluent,
+      locale,
       renegotiateLocale: negotiateLocale,
       useLocale,
       getLocale: getNegotiatedLocale,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,8 +22,23 @@ export class I18n<C extends Context = Context> {
     this.config = { defaultLocale: "en", ...config };
     this.fluent = new Fluent(this.config.fluentOptions);
     if (config.directory) {
-      this.loadLocalesDirSync(config.directory);
+      try {
+        this.loadLocalesDirSync(config.directory);
+      } catch (e) {
+        // TODO try to guess the Deno error and offer another solution.
+        console.error(e);
+      }
     }
+  }
+
+  static initAsync<C extends Context = Context>(
+    config: Partial<I18nConfig<C>>,
+  ) {
+    const instance = new this(config);
+    if (config.directory) {
+      instance.loadLocalesDir(config.directory);
+    }
+    return instance;
   }
 
   /**

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -151,11 +151,17 @@ function middleware<C extends Context = Context>(
     }
 
     async function getNegotiatedLocale(): Promise<string> {
-      return await localeNegotiator?.(ctx) ??
-        // deno-lint-ignore no-explicit-any
-        (await (useSession && (ctx as any).session))?.__language_code ??
+      // deno-lint-ignore no-explicit-any
+      return (await (useSession && (ctx as any).session))?.__language_code ??
         ctx.from?.language_code ??
         defaultLocale;
+    }
+
+    // Determining the locale to use for translations
+    async function negotiateLocale(): Promise<void> {
+      const negotiatedLocale = await localeNegotiator?.(ctx) ??
+        await getNegotiatedLocale();
+      useLocale(negotiatedLocale);
     }
 
     async function setLocale(locale: LocaleId): Promise<void> {
@@ -173,12 +179,6 @@ should either enable sessions or use `ctx.i18n.useLocale()` instead.",
       // deno-lint-ignore no-explicit-any
       (await (ctx as any).session).__language_code = locale;
       await negotiateLocale();
-    }
-
-    // Determining the locale to use for translations
-    async function negotiateLocale(): Promise<void> {
-      const negotiatedLocale = await getNegotiatedLocale();
-      useLocale(negotiatedLocale);
     }
 
     // Also exports ctx object properties for accessing them directly from

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface I18nFlavor {
   i18n: {
     /** Fluent instance used internally. */
     fluent: Fluent;
+    /** Get current user language code */
+    locale: LocaleId;
     /** Returns the current locale. */
     getLocale(): Promise<string>;
     /**


### PR DESCRIPTION
#### TODO

- [x] 4fdda23ea94b7a02342c4b66cccacdf104973f78 Improve `getLocale` by moving `localeNegotiator` (a custom negotiator rule) to `setLocale` to avoid unnecessary calling.
- [x] 9880b42e678489882f9676a7f149596024593224 Allow to get current language as property -> https://t.me/grammyjs/86458
- [ ] ~~Move `loadLocalesDirSync` to middleware and use the **async** version instead (waiting for idea feedback)~~
- [x] Create `initAsync` for Deno Deploy case


#### Warning
The 2 commits are not fully tested yet.