### PR TITLE
fix: make ctx.i18n non-enumerable

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -193,13 +193,18 @@ should either enable sessions or use `ctx.i18n.useLocale()` instead.",
       });
     }
 
-    ctx.i18n = {
-      fluent,
-      renegotiateLocale: negotiateLocale,
-      useLocale,
-      getLocale: getNegotiatedLocale,
-      setLocale,
-    };
+    Object.defineProperty(ctx, "i18n", {
+      value: {
+        fluent,
+        renegotiateLocale: negotiateLocale,
+        useLocale,
+        getLocale: getNegotiatedLocale,
+        setLocale,
+      },
+      // Allow redefine property. This is necessary to be able to install the plugin
+      // inside the conversation even if the plugin is already installed globally.
+      writable: true,
+    });
     ctx.t = translateWrapper;
     ctx.translate = translateWrapper;
 


### PR DESCRIPTION
Make `ctx.i18n` non-enumerable to exclude from serialisation in conversations, as discussed in
https://t.me/grammyjs/107171