### PR TITLE
Allow overriding translations

### DIFF
--- a/src/fluent.ts
+++ b/src/fluent.ts
@@ -148,10 +148,14 @@ export class Fluent {
     );
     // Find the best match for the specified locale
     const matchedLocales = negotiateLanguages(locales, availableLocales);
-    // For matched locales, find the first bundle they're in.
-    const matchedBundles = matchedLocales.map((locale) => {
-      return bundles.find((bundle) => bundle.locales.includes(locale));
-    }).filter((bundle) => bundle !== undefined) as FluentBundle[];
+    // For matched locales, find the bundles they're in.
+    const matchedBundles = matchedLocales.reduce<FluentBundle[]>(
+      (acc, locale) => [
+        ...acc,
+        ...bundles.filter((bundle) => bundle.locales.includes(locale)),
+      ],
+      [],
+    );
 
     // Add the default bundle to the end, so it'll be used if other bundles fails.
     if (this.defaultBundle) matchedBundles.push(this.defaultBundle);

--- a/tests/fluent_test.ts
+++ b/tests/fluent_test.ts
@@ -183,3 +183,25 @@ Deno.test("warnings", async (t) => {
     },
   );
 });
+
+Deno.test("multiple bundles", async () => {
+  const fluent = new Fluent({
+    warningHandler: () => {}
+  });
+
+  await fluent.addTranslation({ locales: "en", source: "hi = hello" });
+  await fluent.addTranslation({ locales: "en", source: "planet = world\nhi = error" });
+  await fluent.addTranslation({ locales: "en", source: "less = more" });
+
+  await fluent.addTranslation({ locales: "it", source: "hi = ciao" });
+  await fluent.addTranslation({ locales: "it", source: "planet = mondo\nhi = errore" });
+  await fluent.addTranslation({ locales: "it", source: "less = più" });
+
+  assertEquals(fluent.translate("en", "hi"), "hello");
+  assertEquals(fluent.translate("en", "planet"), "world");
+  assertEquals(fluent.translate("en", "less"), "more");
+
+  assertEquals(fluent.translate("it", "hi"), "ciao");
+  assertEquals(fluent.translate("it", "planet"), "mondo");
+  assertEquals(fluent.translate("it", "less"), "più");
+})

--- a/tests/fluent_test.ts
+++ b/tests/fluent_test.ts
@@ -186,15 +186,21 @@ Deno.test("warnings", async (t) => {
 
 Deno.test("multiple bundles", async () => {
   const fluent = new Fluent({
-    warningHandler: () => {}
+    warningHandler: () => {},
   });
 
   await fluent.addTranslation({ locales: "en", source: "hi = hello" });
-  await fluent.addTranslation({ locales: "en", source: "planet = world\nhi = error" });
+  await fluent.addTranslation({
+    locales: "en",
+    source: "planet = world\nhi = error",
+  });
   await fluent.addTranslation({ locales: "en", source: "less = more" });
 
   await fluent.addTranslation({ locales: "it", source: "hi = ciao" });
-  await fluent.addTranslation({ locales: "it", source: "planet = mondo\nhi = errore" });
+  await fluent.addTranslation({
+    locales: "it",
+    source: "planet = mondo\nhi = errore",
+  });
   await fluent.addTranslation({ locales: "it", source: "less = più" });
 
   assertEquals(fluent.translate("en", "hi"), "hello");
@@ -204,4 +210,4 @@ Deno.test("multiple bundles", async () => {
   assertEquals(fluent.translate("it", "hi"), "ciao");
   assertEquals(fluent.translate("it", "planet"), "mondo");
   assertEquals(fluent.translate("it", "less"), "più");
-})
+});


### PR DESCRIPTION
Closes #48

For some use-cases it would be useful to have the ability to override certain translations programmatically, for example by loading multiple translation files before loading the default translations.

This pull request changes the `matchBundles` function to allow matching multiple bundles for the same locale before falling back to the default bundle.

Within the bot it is then possible to use a piece of code such as:
```ts
function loadLocaleData() {
  if (process.env.LOCALE_OVERRIDES) {
    const overrides = process.env.LOCALE_OVERRIDES.split(',');
    overrides.forEach((override: string) => {
      const directory = path.join(__dirname, 'i18n', override);
      console.log('loading locale override', override);
      i18n.loadLocalesDirSync(directory);
    });
  }

  i18n.loadLocalesDirSync(path.join(__dirname, 'i18n'));
}
```

When paired with a properly implemented warnings handler it allows properly overriding translations.
```ts
{
  fluentOptions: {
    warningHandler: (warning) => {
      if (
        warning.type === TranslateWarnings.MISSING_MESSAGE &&
        !warning.bundle.hasMessage('-override')
      ) {
        // ignore warning on override file
        return;
      }

      defaultWarningHandler(console.log)(warning);
    },
  },
}
```
Note: the above example assumes a message with key '-override' exists on override files.
